### PR TITLE
Added rule to load after Vanilla Expanded Framework

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -24,6 +24,9 @@
 			<downloadUrl>https://github.com/Vanilla-Expanded/VanillaExpandedFramework</downloadUrl>
 		</li>
 	</modDependencies>
+	<loadAfter>
+		<li>OskarPotocki.VanillaFactionsExpanded.Core</li>
+	</loadAfter>
 	<packageId>VanillaExpanded.VFEArt</packageId>
     <description>Vanilla Furniture Expanded - Art module is something long overdue. Being an artist, I struggled to comprehend why the only type of sculptures we can make are small, large or grand artworks on a tiny pedestal. It made Artistic skill pretty much undesirable. Come on, how many times have you said to yourself “Oh crikey, that’s another pawn that can only do art”? 
 


### PR DESCRIPTION
I've changed `About.xml` file to add a rule to make this mod load after Vanilla Expanded Framework.

This mod relies on loading after VEF due to the VEF prepatches - it will cause errors and break Royalty/Ideology compatibility if loaded before those are applied.

This change won't fix the issue if the mod ends up loaded before VEF - however, this should help lower the chances someone will do that by accident, as auto-sorting mods should now properly place this mod in the correct location. It will also let people with incorrect load order know that it's incorrect if they check their mod list.

The errors in question if the mod is loaded before VEF:
```
[Vanilla Furniture Expanded - Art] Patch operation Verse.PatchOperationFindMod(Ideology) failed
file: C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\VanillaFurnitureExpanded-Art\1.5\Patches\Ideology.xml 

[Vanilla Furniture Expanded - Art] Patch operation Verse.PatchOperationFindMod(Royalty) failed
file: C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\VanillaFurnitureExpanded-Art\1.5\Patches\Royalty.xml 
```

The prepatches this relies on:
- https://github.com/Vanilla-Expanded/VanillaExpandedFramework/blob/main/1.5/Patches/Royalty/Royalty_PrePatches.xml
- https://github.com/Vanilla-Expanded/VanillaExpandedFramework/blob/main/1.5/Patches/Ideology/Ideology_PrePatches.xml